### PR TITLE
Feature: Enable Client and Server Services in Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,14 @@
 version: '3.8'
 
 services:
-  # client:
-  #   build:
-  #     context: ./client
-  #     dockerfile: Dockerfile
-  #   image: hlexnc/devablos-project-v2-client
-  #   platform: linux/amd64
-  #   ports:
-  #     - "3000:3000"
+  client:
+    build:
+      context: ./client
+      dockerfile: Dockerfile
+    image: hlexnc/devablos-project-v2-client
+    platform: linux/amd64
+    ports:
+      - "3000:3000"
 
   server:
     build:


### PR DESCRIPTION
## Description
This pull request enables the client and server services within the Docker Compose configuration, allowing for streamlined multi-container deployments. The updated `docker-compose.yml` file includes configurations for both the client and server applications, ensuring they can be built, deployed, and run together efficiently.

## Key Changes
1. **Client Service Configuration**:
    - Added the client service to the Docker Compose file.
    - Configured the client service to build from the `./client` directory using the provided Dockerfile.
    - Exposed port 3000 for the client application.

2. **Server Service Configuration**:
    - The server service remains configured to build from the current directory using the provided Dockerfile.
    - Exposed ports 5000 and 5001 for the server application.

## Summary
These updates enhance the Docker Compose configuration by including both client and server services, facilitating a cohesive development and deployment environment for the project. This setup ensures that both components can be managed and scaled together seamlessly.